### PR TITLE
Refactor/use function not class

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "webpack --mode production",
     "prepare": "webpack --config webpack.config.js",
     "watch": "webpack --config webpack.dev.js --watch",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "format": "prettier --config .prettierrc --write \"src/**/*.{ts,js}\""
   },
   "author": "antyuntyun",
   "license": "ISC",

--- a/src/accessTokenInitialize.ts
+++ b/src/accessTokenInitialize.ts
@@ -45,7 +45,7 @@ export async function accessTokenInitialize(): Promise<number> {
     );
     await sleep(1500);
     // 1.5 seconds later
-    // open iita admin by web default web browser
+    // open qiita admin by web default web browser
     await open('https://qiita.com/settings/applications');
 
     // ユーザ入出力形式指定

--- a/src/accessTokenInitialize.ts
+++ b/src/accessTokenInitialize.ts
@@ -6,113 +6,107 @@ import { Answers, prompt, QuestionCollection } from 'inquirer';
 import sleep from 'sleep-promise';
 import { User } from '@/types/qiita';
 
-export class accessTokenInitialize {
-  async exec(): Promise<number> {
-    try {
-      const homeDir =
-        process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      const qiitaDir = `${homeDir}/.qiita`;
-      if (!fs.existsSync(qiitaDir)) {
-        fs.mkdirSync(qiitaDir);
-      }
-      const filePath = `${qiitaDir}/qiita.json`;
-      // ユーザ入力形式指定用変数
-      let inputQuestions: QuestionCollection;
+export async function accessTokenInitialize(): Promise<number> {
+  try {
+    const homeDir =
+      process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    const qiitaDir = `${homeDir}/.qiita`;
+    if (!fs.existsSync(qiitaDir)) {
+      fs.mkdirSync(qiitaDir);
+    }
+    const filePath = `${qiitaDir}/qiita.json`;
+    // ユーザ入力形式指定用変数
+    let inputQuestions: QuestionCollection;
 
-      if (fs.existsSync(filePath)) {
-        // ユーザ入出力形式指定
-        inputQuestions = [
-          {
-            type: 'confirm',
-            message:
-              '設定ファイルが既に存在します。設定が上書きされますが、よろしいですか？: ',
-            name: 'yesNoBool',
-          },
-        ];
-        const answers: Answers | { yesNoBool: boolean } = await prompt(
-          inputQuestions
-        );
-        if (!answers.yesNoBool) {
-          console.log(
-            '\n' + emoji.get('hatched_chick') + ' 処理を中止しました\n'
-          );
-          return 0;
-        }
-      }
-
-      console.log(
-        'Qiiaの管理者画面にてアクセストークンを発行し、トークンをcliに入力してください\n'
-      );
-      await sleep(1500);
-      // 1.5 seconds later
-      // open iita admin by web default web browser
-      await open('https://qiita.com/settings/applications');
-
+    if (fs.existsSync(filePath)) {
       // ユーザ入出力形式指定
       inputQuestions = [
         {
-          type: 'input',
-          message: 'Qiita AccessToken: ',
-          name: 'token',
+          type: 'confirm',
+          message:
+            '設定ファイルが既に存在します。設定が上書きされますが、よろしいですか？: ',
+          name: 'yesNoBool',
         },
       ];
-
-      // ユーザ入力(prompt())
-      // TODO: 入力されるアクセストークンをシェル上で非表示にする
-      const answers: Answers | { token: string } = await prompt(inputQuestions);
-      // const token = JSON.stringify(answers, null, '  ');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const token: string = answers.token;
-      await axios
-        .get<User>('https://qiita.com/api/v2/authenticated_user', {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        })
-        .then((res) => {
-          const qiitaUser = {
-            id: res.data.id,
-            token: token,
-          };
-          const qiitaUserJson = JSON.stringify(qiitaUser, null, '  ');
-          // 設定ファイル書き込み
-          fs.writeFileSync(filePath, qiitaUserJson);
-          fs.appendFileSync(filePath, '\n');
-        });
-
-      // 作業ディレクトリに記事用フォルダを作成
-      const articleDir = 'articles';
-      if (!fs.existsSync(articleDir)) {
-        fs.mkdirSync(articleDir);
+      const answers: Answers | { yesNoBool: boolean } = await prompt(
+        inputQuestions
+      );
+      if (!answers.yesNoBool) {
+        console.log(
+          '\n' + emoji.get('hatched_chick') + ' 処理を中止しました\n'
+        );
+        return 0;
       }
-
-      // 処理完了メッセージ
-      console.log(
-        '\n' +
-          emoji.get('sparkles') +
-          ' Access token initialize completed. ' +
-          emoji.get('sparkles') +
-          '\n'
-      );
-      console.log('Your token has been saved to the following path:');
-      console.log('\n' + '\t' + filePath + '\n');
-      console.log('Your articles folder:');
-      console.log('\n' + '\t' + process.cwd() + '/articles/' + '\n');
-      return 0;
-    } catch (e) {
-      const red = '\u001b[31m';
-      const reset = '\u001b[0m';
-      console.error(
-        '\n' +
-          red +
-          'error in get Qiita access token initialize: ' +
-          reset +
-          '\n'
-      );
-      console.error(e);
-      return -1;
     }
-    return 1;
+
+    console.log(
+      'Qiiaの管理者画面にてアクセストークンを発行し、トークンをcliに入力してください\n'
+    );
+    await sleep(1500);
+    // 1.5 seconds later
+    // open iita admin by web default web browser
+    await open('https://qiita.com/settings/applications');
+
+    // ユーザ入出力形式指定
+    inputQuestions = [
+      {
+        type: 'input',
+        message: 'Qiita AccessToken: ',
+        name: 'token',
+      },
+    ];
+
+    // ユーザ入力(prompt())
+    // TODO: 入力されるアクセストークンをシェル上で非表示にする
+    const answers: Answers | { token: string } = await prompt(inputQuestions);
+    // const token = JSON.stringify(answers, null, '  ');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const token: string = answers.token;
+    await axios
+      .get<User>('https://qiita.com/api/v2/authenticated_user', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      .then((res) => {
+        const qiitaUser = {
+          id: res.data.id,
+          token: token,
+        };
+        const qiitaUserJson = JSON.stringify(qiitaUser, null, '  ');
+        // 設定ファイル書き込み
+        fs.writeFileSync(filePath, qiitaUserJson);
+        fs.appendFileSync(filePath, '\n');
+      });
+
+    // 作業ディレクトリに記事用フォルダを作成
+    const articleDir = 'articles';
+    if (!fs.existsSync(articleDir)) {
+      fs.mkdirSync(articleDir);
+    }
+
+    // 処理完了メッセージ
+    console.log(
+      '\n' +
+        emoji.get('sparkles') +
+        ' Access token initialize completed. ' +
+        emoji.get('sparkles') +
+        '\n'
+    );
+    console.log('Your token has been saved to the following path:');
+    console.log('\n' + '\t' + filePath + '\n');
+    console.log('Your articles folder:');
+    console.log('\n' + '\t' + process.cwd() + '/articles/' + '\n');
+    return 0;
+  } catch (e) {
+    const red = '\u001b[31m';
+    const reset = '\u001b[0m';
+    console.error(
+      '\n' + red + 'error in get Qiita access token initialize: ' + reset + '\n'
+    );
+    console.error(e);
+    return -1;
   }
+  return 1;
 }

--- a/src/getArticle.ts
+++ b/src/getArticle.ts
@@ -5,42 +5,41 @@ import fs from 'fs';
 // import qiitaSetting from '../qiita.json';
 import { QiitaPost } from '@/types/qiita';
 
-export class getArticle {
-  async exec(articleId: string): Promise<number> {
-    try {
-      // アクセストークン情報をqiita.jsonから取得
-      // qiita init で事前に設定されている必要あり
-      const homeDir =
-        process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      const qiitaDir = `${homeDir}/.qiita`;
-      const filePath = `${qiitaDir}/qiita.json`;
-      if (!fs.existsSync(filePath)) {
-        console.log(
-          emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
-        );
-        console.log(
-          'qiita init コマンドを実行してアクセストークンを設定してください.\n'
-        );
-        return -1;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const qiitaSetting: { token: string } = JSON.parse(
-        fs.readFileSync(filePath, 'utf-8')
+export async function getArticle(articleId: string): Promise<number> {
+  try {
+    // アクセストークン情報をqiita.jsonから取得
+    // qiita init で事前に設定されている必要あり
+    const homeDir =
+      process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    const qiitaDir = `${homeDir}/.qiita`;
+    const filePath = `${qiitaDir}/qiita.json`;
+    if (!fs.existsSync(filePath)) {
+      console.log(
+        emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
       );
+      console.log(
+        'qiita init コマンドを実行してアクセストークンを設定してください.\n'
+      );
+      return -1;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const qiitaSetting: { token: string } = JSON.parse(
+      fs.readFileSync(filePath, 'utf-8')
+    );
 
-      await axios
-        .get<QiitaPost>('https://qiita.com/api/v2/items/' + articleId, {
-          headers: {
-            Authorization: `Bearer ${qiitaSetting.token}`,
-          },
-        })
-        .then((res) => {
-          // make .md file from res data
-          const dir: string = 'articles/' + res.data.title + '/';
-          const filePath: string = dir + res.data.id + '.md';
-          fs.mkdirSync(dir, { recursive: true });
-          const frontMatter = `---
+    await axios
+      .get<QiitaPost>('https://qiita.com/api/v2/items/' + articleId, {
+        headers: {
+          Authorization: `Bearer ${qiitaSetting.token}`,
+        },
+      })
+      .then((res) => {
+        // make .md file from res data
+        const dir: string = 'articles/' + res.data.title + '/';
+        const filePath: string = dir + res.data.id + '.md';
+        fs.mkdirSync(dir, { recursive: true });
+        const frontMatter = `---
 id: ${res.data.id}
 title: ${res.data.title}
 created_at: ${res.data.created_at}
@@ -50,20 +49,19 @@ private: ${String(res.data.private)}
 url: ${String(res.data.url)}
 likes_count: ${String(res.data.likes_count)}
 ---`;
-          // write frontMatter
-          fs.writeFileSync(filePath, frontMatter);
-          // write body
-          fs.appendFileSync(filePath, res.data.body);
+        // write frontMatter
+        fs.writeFileSync(filePath, frontMatter);
+        // write body
+        fs.appendFileSync(filePath, res.data.body);
 
-          return 0;
-        });
-    } catch (e) {
-      const red = '\u001b[31m';
-      const reset = '\u001b[0m';
-      console.error('\n' + red + 'error in get Qiita posts: ' + reset + '\n');
-      console.error(e);
-      return -1;
-    }
-    return 1;
+        return 0;
+      });
+  } catch (e) {
+    const red = '\u001b[31m';
+    const reset = '\u001b[0m';
+    console.error('\n' + red + 'error in get Qiita posts: ' + reset + '\n');
+    console.error(e);
+    return -1;
   }
+  return 1;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,11 +39,11 @@ Remark:
 `;
 
   private commandMap = new Map<CommandType, () => number | Promise<number>>([
-    ['init', () => new accessTokenInitialize().exec()],
-    ['pull:article', () => new pullArticle().exec()],
-    ['new:article', () => new newArticle().exec()],
-    ['post:article', () => new postArticle().exec()],
-    ['patch:article', () => new patchArticle().exec()],
+    ['init', () => accessTokenInitialize()],
+    ['pull:article', () => pullArticle()],
+    ['new:article', () => newArticle()],
+    ['post:article', () => postArticle()],
+    ['patch:article', () => patchArticle()],
     ['sync', () => new Calc().add(1, 2)],
   ]);
 

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -12,211 +12,206 @@ import yaml from 'yaml';
 import unified from 'unified';
 import { QiitaPostResponse } from '~/types/qiita';
 
-export class patchArticle {
-  async exec(): Promise<number> {
-    try {
-      // アクセストークン情報をqiita.jsonから取得
-      // qiita init で事前に設定されている必要あり
-      const homeDir =
-        process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      const qiitaDir = `${homeDir}/.qiita`;
-      const filePath = `${qiitaDir}/qiita.json`;
-      if (!fs.existsSync(filePath)) {
-        console.log(
-          emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
-        );
-        console.log(
-          'qiita init コマンドを実行してアクセストークンを設定してください.\n'
-        );
-        return -1;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const qiitaSetting: { token: string } = JSON.parse(
-        fs.readFileSync(filePath, 'utf-8')
-      );
-
-      console.log('Qiita 記事投稿\n\n');
+export async function patchArticle(): Promise<number> {
+  try {
+    // アクセストークン情報をqiita.jsonから取得
+    // qiita init で事前に設定されている必要あり
+    const homeDir =
+      process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    const qiitaDir = `${homeDir}/.qiita`;
+    const filePath = `${qiitaDir}/qiita.json`;
+    if (!fs.existsSync(filePath)) {
       console.log(
-        'aricleディレクトリのある作業ディレクトリでコマンド実行している前提での処理です.'
+        emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
       );
       console.log(
-        'articleディレクトリ内の will_be_patched.md ファイルが投稿候補記事として認識されます\n\n'
+        'qiita init コマンドを実行してアクセストークンを設定してください.\n'
       );
-      const articleBaseDir = 'articles';
-
-      //   TODO: utill化
-      const listFiles = (dir: string): string[] =>
-        fs
-          .readdirSync(dir, { withFileTypes: true })
-          .flatMap((dirent) =>
-            dirent.isFile()
-              ? [`${dir}/${dirent.name}`]
-              : listFiles(`${dir}/${dirent.name}`)
-          );
-
-      // ファイル名がwill_be_patched.mdとなっているものを取得
-      const filePathList: string[] = listFiles(articleBaseDir).filter((item) =>
-        item.includes('will_be_patched.md')
-      );
-
-      if (filePathList.length === 0) {
-        console.log(
-          '\n' +
-            emoji.get('disappointed') +
-            ' There are no "will_be_patched.md" files\n'
-        );
-        console.log(emoji.get('hatched_chick') + ' 処理を中止しました\n');
-        return 1;
-      }
-      const articleNameList: string[] = filePathList.map((item) => {
-        // articlesフォルダ直下に記事名が記載されているフォルダが存在する前提
-        return item.split('/')[1];
-      });
-
-      //   typ: 'checkbox'とすることで、複数選択可能状態にできるが、シェル上で挙動が不安定になるので、一旦単一選択のlistを採用
-      const inputQuestions: QuestionCollection = [
-        {
-          type: 'list',
-          message: '修正アップロードする記事を選択してください: ',
-          name: 'uploadArticles',
-          choices: articleNameList,
-        },
-      ];
-      const answers: Answers | { uploadArticles: string } = await prompt(
-        inputQuestions
-      );
-
-      //   TODO: 複数選択対応
-      const uploadArticlePath: string | undefined = listFiles(
-        articleBaseDir
-      ).find((item) => item.includes(answers.uploadArticles));
-
-      // front-matter付きmarkdownのパース
-      const inputArticle = fs.readFileSync(String(uploadArticlePath));
-      const processor = unified()
-        .use(remarkParse)
-        .use(remarkFrontmatter, [
-          {
-            type: 'yaml',
-            marker: '-',
-            anywhere: false, // ファイルの冒頭に Front Matter がある前提で探索する
-          },
-        ])
-        .use(remarkExtractFrontmatter, {
-          yaml: yaml.parse,
-          name: 'frontMatter', // result.data 配下のキー名を決める
-        })
-        .use(remarkRehype)
-        .use(rehypeStringify);
-      interface parseResult {
-        data: {
-          frontMatter: {
-            id: null | string;
-            title: null | string;
-            tags: null | [];
-          };
-        };
-        messages: unknown;
-        history: unknown;
-        cwd: string;
-        contents: unknown | string;
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result: any | parseResult = await processor.process(inputArticle);
-      //   console.log(result);
-
-      // 記事タイトル
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const title: unknown | string = result.data.frontMatter.title;
-      // 記事のタグ
-      interface Tag {
-        name: null | string;
-        versions: null | string[];
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const tags: unknown | Tag[] = result.data.frontMatter.tags;
-
-      if (!tags) {
-        console.log(
-          '\n' +
-            emoji.get('disappointed') +
-            ' 選択した記事にタグが設定されていません.\n記事を投稿するには一つ以上タグが設定されている必要があります.\n'
-        );
-        return -1;
-      }
-
-      // 記事本文
-      // bufferでなく文字列として読み込み
-      const articleContents = fs.readFileSync(
-        String(uploadArticlePath),
-        'utf-8'
-      );
-      // フロント・マターを区切り文字で検索し、フロント・マター以降を抽出
-      const startIndex = articleContents.indexOf(
-        '---',
-        articleContents.indexOf('---') + 1
-      );
-      const articleContentsBody = articleContents.substr(startIndex + 4);
-
-      // 記事id
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const articleId: unknown | string = result.data.frontMatter.id;
-
-      await axios
-        .patch<QiitaPostResponse>(
-          'https://qiita.com/api/v2/items/' + String(articleId),
-          {
-            body: articleContentsBody,
-            coediting: false,
-            group_url_name: 'dev',
-            private: false,
-            tags: tags,
-            title: title,
-            tweet: false,
-          },
-          {
-            headers: {
-              Authorization: `Bearer ${qiitaSetting.token}`,
-            },
-          }
-        )
-        .then((res) => {
-          //   console.log(res);
-          if (res.status === 200) {
-            // 記事投稿成功
-            // 処理完了メッセージ
-            console.log(
-              '\n' +
-                emoji.get('sparkles') +
-                ' Article "' +
-                String(title) +
-                '" is patched' +
-                emoji.get('sparkles') +
-                '\n'
-            );
-          } else {
-            // 記事投稿失敗
-            console.log(
-              '\n' + emoji.get('disappointed') + ' fail to patch article.\n'
-            );
-            return -1;
-          }
-        });
-      // ファイルリネーム
-      fs.renameSync(
-        String(uploadArticlePath),
-        String(uploadArticlePath).replace('will_be_patched', String(articleId))
-      );
-      return 0;
-    } catch (e) {
-      const red = '\u001b[31m';
-      const reset = '\u001b[0m';
-      console.error('\n' + red + 'error in patch article: ' + reset + '\n');
-      console.error(e);
       return -1;
     }
-    return 1;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const qiitaSetting: { token: string } = JSON.parse(
+      fs.readFileSync(filePath, 'utf-8')
+    );
+
+    console.log('Qiita 記事投稿\n\n');
+    console.log(
+      'aricleディレクトリのある作業ディレクトリでコマンド実行している前提での処理です.'
+    );
+    console.log(
+      'articleディレクトリ内の will_be_patched.md ファイルが投稿候補記事として認識されます\n\n'
+    );
+    const articleBaseDir = 'articles';
+
+    //   TODO: utill化
+    const listFiles = (dir: string): string[] =>
+      fs
+        .readdirSync(dir, { withFileTypes: true })
+        .flatMap((dirent) =>
+          dirent.isFile()
+            ? [`${dir}/${dirent.name}`]
+            : listFiles(`${dir}/${dirent.name}`)
+        );
+
+    // ファイル名がwill_be_patched.mdとなっているものを取得
+    const filePathList: string[] = listFiles(articleBaseDir).filter((item) =>
+      item.includes('will_be_patched.md')
+    );
+
+    if (filePathList.length === 0) {
+      console.log(
+        '\n' +
+          emoji.get('disappointed') +
+          ' There are no "will_be_patched.md" files\n'
+      );
+      console.log(emoji.get('hatched_chick') + ' 処理を中止しました\n');
+      return 1;
+    }
+    const articleNameList: string[] = filePathList.map((item) => {
+      // articlesフォルダ直下に記事名が記載されているフォルダが存在する前提
+      return item.split('/')[1];
+    });
+
+    //   typ: 'checkbox'とすることで、複数選択可能状態にできるが、シェル上で挙動が不安定になるので、一旦単一選択のlistを採用
+    const inputQuestions: QuestionCollection = [
+      {
+        type: 'list',
+        message: '修正アップロードする記事を選択してください: ',
+        name: 'uploadArticles',
+        choices: articleNameList,
+      },
+    ];
+    const answers: Answers | { uploadArticles: string } = await prompt(
+      inputQuestions
+    );
+
+    //   TODO: 複数選択対応
+    const uploadArticlePath: string | undefined = listFiles(
+      articleBaseDir
+    ).find((item) => item.includes(answers.uploadArticles));
+
+    // front-matter付きmarkdownのパース
+    const inputArticle = fs.readFileSync(String(uploadArticlePath));
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkFrontmatter, [
+        {
+          type: 'yaml',
+          marker: '-',
+          anywhere: false, // ファイルの冒頭に Front Matter がある前提で探索する
+        },
+      ])
+      .use(remarkExtractFrontmatter, {
+        yaml: yaml.parse,
+        name: 'frontMatter', // result.data 配下のキー名を決める
+      })
+      .use(remarkRehype)
+      .use(rehypeStringify);
+    interface parseResult {
+      data: {
+        frontMatter: {
+          id: null | string;
+          title: null | string;
+          tags: null | [];
+        };
+      };
+      messages: unknown;
+      history: unknown;
+      cwd: string;
+      contents: unknown | string;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: any | parseResult = await processor.process(inputArticle);
+    //   console.log(result);
+
+    // 記事タイトル
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const title: unknown | string = result.data.frontMatter.title;
+    // 記事のタグ
+    interface Tag {
+      name: null | string;
+      versions: null | string[];
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const tags: unknown | Tag[] = result.data.frontMatter.tags;
+
+    if (!tags) {
+      console.log(
+        '\n' +
+          emoji.get('disappointed') +
+          ' 選択した記事にタグが設定されていません.\n記事を投稿するには一つ以上タグが設定されている必要があります.\n'
+      );
+      return -1;
+    }
+
+    // 記事本文
+    // bufferでなく文字列として読み込み
+    const articleContents = fs.readFileSync(String(uploadArticlePath), 'utf-8');
+    // フロント・マターを区切り文字で検索し、フロント・マター以降を抽出
+    const startIndex = articleContents.indexOf(
+      '---',
+      articleContents.indexOf('---') + 1
+    );
+    const articleContentsBody = articleContents.substr(startIndex + 4);
+
+    // 記事id
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const articleId: unknown | string = result.data.frontMatter.id;
+
+    await axios
+      .patch<QiitaPostResponse>(
+        'https://qiita.com/api/v2/items/' + String(articleId),
+        {
+          body: articleContentsBody,
+          coediting: false,
+          group_url_name: 'dev',
+          private: false,
+          tags: tags,
+          title: title,
+          tweet: false,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${qiitaSetting.token}`,
+          },
+        }
+      )
+      .then((res) => {
+        //   console.log(res);
+        if (res.status === 200) {
+          // 記事投稿成功
+          // 処理完了メッセージ
+          console.log(
+            '\n' +
+              emoji.get('sparkles') +
+              ' Article "' +
+              String(title) +
+              '" is patched' +
+              emoji.get('sparkles') +
+              '\n'
+          );
+        } else {
+          // 記事投稿失敗
+          console.log(
+            '\n' + emoji.get('disappointed') + ' fail to patch article.\n'
+          );
+          return -1;
+        }
+      });
+    // ファイルリネーム
+    fs.renameSync(
+      String(uploadArticlePath),
+      String(uploadArticlePath).replace('will_be_patched', String(articleId))
+    );
+    return 0;
+  } catch (e) {
+    const red = '\u001b[31m';
+    const reset = '\u001b[0m';
+    console.error('\n' + red + 'error in patch article: ' + reset + '\n');
+    console.error(e);
+    return -1;
   }
+  return 1;
 }

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -14,213 +14,206 @@ import unified from 'unified';
 import { QiitaPostResponse } from '~/types/qiita';
 import { getArticle } from './getArticle';
 
-export class postArticle {
-  async exec(): Promise<number> {
-    try {
-      // アクセストークン情報をqiita.jsonから取得
-      // qiita init で事前に設定されている必要あり
-      const homeDir =
-        process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      const qiitaDir = `${homeDir}/.qiita`;
-      const filePath = `${qiitaDir}/qiita.json`;
-      if (!fs.existsSync(filePath)) {
-        console.log(
-          emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
-        );
-        console.log(
-          'qiita init コマンドを実行してアクセストークンを設定してください.\n'
-        );
-        return -1;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const qiitaSetting: { token: string } = JSON.parse(
-        fs.readFileSync(filePath, 'utf-8')
-      );
-
-      console.log('Qiita 記事投稿\n\n');
+export async function postArticle(): Promise<number> {
+  try {
+    // アクセストークン情報をqiita.jsonから取得
+    // qiita init で事前に設定されている必要あり
+    const homeDir =
+      process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    const qiitaDir = `${homeDir}/.qiita`;
+    const filePath = `${qiitaDir}/qiita.json`;
+    if (!fs.existsSync(filePath)) {
       console.log(
-        'aricleディレクトリのある作業ディレクトリでコマンド実行している前提での処理です.'
+        emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
       );
       console.log(
-        'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
+        'qiita init コマンドを実行してアクセストークンを設定してください.\n'
       );
-      const articleBaseDir = 'articles';
-
-      //   TODO: utill化
-      const listFiles = (dir: string): string[] =>
-        fs
-          .readdirSync(dir, { withFileTypes: true })
-          .flatMap((dirent) =>
-            dirent.isFile()
-              ? [`${dir}/${dirent.name}`]
-              : listFiles(`${dir}/${dirent.name}`)
-          );
-
-      // ファイル名がnot_uploaded.mdとなっているものを取得
-      const filePathList: string[] = listFiles(articleBaseDir).filter((item) =>
-        item.includes('not_uploaded.md')
-      );
-
-      if (filePathList.length === 0) {
-        console.log(
-          '\n' +
-            emoji.get('disappointed') +
-            ' There are no "not_uploaded.md" files\n'
-        );
-        console.log(emoji.get('hatched_chick') + ' 処理を中止しました\n');
-        return 1;
-      }
-      const articleNameList: string[] = filePathList.map((item) => {
-        // articlesフォルダ直下に記事名が記載されているフォルダが存在する前提
-        return item.split('/')[1];
-      });
-
-      //   typ: 'checkbox'とすることで、複数選択可能状態にできるが、シェル上で挙動が不安定になるので、一旦単一選択のlistを採用
-      const inputQuestions: QuestionCollection = [
-        {
-          type: 'list',
-          message: 'アップロードする記事を選択してください: ',
-          name: 'uploadArticles',
-          choices: articleNameList,
-        },
-      ];
-      const answers: Answers | { uploadArticles: string } = await prompt(
-        inputQuestions
-      );
-
-      //   TODO: 複数選択対応
-      const uploadArticlePath: string | undefined = listFiles(
-        articleBaseDir
-      ).find((item) => item.includes(answers.uploadArticles));
-
-      // front-matter付きmarkdownのパース
-      const inputArticle = fs.readFileSync(String(uploadArticlePath));
-      const processor = unified()
-        .use(remarkParse)
-        .use(remarkFrontmatter, [
-          {
-            type: 'yaml',
-            marker: '-',
-            anywhere: false, // ファイルの冒頭に Front Matter がある前提で探索する
-          },
-        ])
-        .use(remarkExtractFrontmatter, {
-          yaml: yaml.parse,
-          name: 'frontMatter', // result.data 配下のキー名を決める
-        })
-        .use(remarkRehype)
-        .use(rehypeStringify);
-      interface parseResult {
-        data: {
-          frontMatter: {
-            id: null | string;
-            title: null | string;
-            tags: null | [];
-          };
-        };
-        messages: unknown;
-        history: unknown;
-        cwd: string;
-        contents: unknown | string;
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result: any | parseResult = await processor.process(inputArticle);
-      //   console.log(result);
-
-      // 記事タイトル
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const title: unknown | string = result.data.frontMatter.title;
-      // 記事のタグ
-      interface Tag {
-        name: null | string;
-        versions: null | string[];
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const tags: unknown | Tag[] = result.data.frontMatter.tags;
-
-      if (!tags) {
-        console.log(
-          '\n' +
-            emoji.get('disappointed') +
-            ' 選択した記事にタグが設定されていません.\n記事を投稿するには一つ以上タグが設定されている必要があります.\n'
-        );
-        return -1;
-      }
-
-      // 記事本文
-      // bufferでなく文字列として読み込み
-      const articleContents = fs.readFileSync(
-        String(uploadArticlePath),
-        'utf-8'
-      );
-      // フロント・マターを区切り文字で検索し、フロント・マター以降を抽出
-      const startIndex = articleContents.indexOf(
-        '---',
-        articleContents.indexOf('---') + 1
-      );
-      const articleContentsBody = articleContents.substr(startIndex + 4);
-
-      // 記事投稿成功時に生成される記事idを格納する
-      let articleId = '';
-
-      await axios
-        .post<QiitaPostResponse>(
-          'https://qiita.com/api/v2/items/',
-          {
-            body: articleContentsBody,
-            coediting: false,
-            group_url_name: 'dev',
-            private: false,
-            tags: tags,
-            title: title,
-            tweet: false,
-          },
-          {
-            headers: {
-              Authorization: `Bearer ${qiitaSetting.token}`,
-            },
-          }
-        )
-        .then((res) => {
-          // console.log(res);
-          if (res.status === 201) {
-            // 記事投稿成功
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            articleId = String(res.data.id);
-            // 処理完了メッセージ
-            console.log(
-              '\n' +
-                emoji.get('sparkles') +
-                ' New Article "' +
-                String(title) +
-                '" is created' +
-                emoji.get('sparkles') +
-                '\n'
-            );
-          } else {
-            // 記事投稿失敗
-            console.log(
-              '\n' + emoji.get('disappointed') + ' fail to post new article.\n'
-            );
-            return -1;
-          }
-        });
-      // 投稿した記事を取得
-      await new getArticle().exec(articleId);
-      // 投稿前状態のファイルを削除
-      fs.unlinkSync(String(uploadArticlePath));
-      return 0;
-    } catch (e) {
-      const red = '\u001b[31m';
-      const reset = '\u001b[0m';
-      console.error(
-        '\n' + red + 'error in create new article: ' + reset + '\n'
-      );
-      console.error(e);
       return -1;
     }
-    return 1;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const qiitaSetting: { token: string } = JSON.parse(
+      fs.readFileSync(filePath, 'utf-8')
+    );
+
+    console.log('Qiita 記事投稿\n\n');
+    console.log(
+      'aricleディレクトリのある作業ディレクトリでコマンド実行している前提での処理です.'
+    );
+    console.log(
+      'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
+    );
+    const articleBaseDir = 'articles';
+
+    //   TODO: utill化
+    const listFiles = (dir: string): string[] =>
+      fs
+        .readdirSync(dir, { withFileTypes: true })
+        .flatMap((dirent) =>
+          dirent.isFile()
+            ? [`${dir}/${dirent.name}`]
+            : listFiles(`${dir}/${dirent.name}`)
+        );
+
+    // ファイル名がnot_uploaded.mdとなっているものを取得
+    const filePathList: string[] = listFiles(articleBaseDir).filter((item) =>
+      item.includes('not_uploaded.md')
+    );
+
+    if (filePathList.length === 0) {
+      console.log(
+        '\n' +
+          emoji.get('disappointed') +
+          ' There are no "not_uploaded.md" files\n'
+      );
+      console.log(emoji.get('hatched_chick') + ' 処理を中止しました\n');
+      return 1;
+    }
+    const articleNameList: string[] = filePathList.map((item) => {
+      // articlesフォルダ直下に記事名が記載されているフォルダが存在する前提
+      return item.split('/')[1];
+    });
+
+    //   typ: 'checkbox'とすることで、複数選択可能状態にできるが、シェル上で挙動が不安定になるので、一旦単一選択のlistを採用
+    const inputQuestions: QuestionCollection = [
+      {
+        type: 'list',
+        message: 'アップロードする記事を選択してください: ',
+        name: 'uploadArticles',
+        choices: articleNameList,
+      },
+    ];
+    const answers: Answers | { uploadArticles: string } = await prompt(
+      inputQuestions
+    );
+
+    //   TODO: 複数選択対応
+    const uploadArticlePath: string | undefined = listFiles(
+      articleBaseDir
+    ).find((item) => item.includes(answers.uploadArticles));
+
+    // front-matter付きmarkdownのパース
+    const inputArticle = fs.readFileSync(String(uploadArticlePath));
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkFrontmatter, [
+        {
+          type: 'yaml',
+          marker: '-',
+          anywhere: false, // ファイルの冒頭に Front Matter がある前提で探索する
+        },
+      ])
+      .use(remarkExtractFrontmatter, {
+        yaml: yaml.parse,
+        name: 'frontMatter', // result.data 配下のキー名を決める
+      })
+      .use(remarkRehype)
+      .use(rehypeStringify);
+    interface parseResult {
+      data: {
+        frontMatter: {
+          id: null | string;
+          title: null | string;
+          tags: null | [];
+        };
+      };
+      messages: unknown;
+      history: unknown;
+      cwd: string;
+      contents: unknown | string;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: any | parseResult = await processor.process(inputArticle);
+    //   console.log(result);
+
+    // 記事タイトル
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const title: unknown | string = result.data.frontMatter.title;
+    // 記事のタグ
+    interface Tag {
+      name: null | string;
+      versions: null | string[];
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const tags: unknown | Tag[] = result.data.frontMatter.tags;
+
+    if (!tags) {
+      console.log(
+        '\n' +
+          emoji.get('disappointed') +
+          ' 選択した記事にタグが設定されていません.\n記事を投稿するには一つ以上タグが設定されている必要があります.\n'
+      );
+      return -1;
+    }
+
+    // 記事本文
+    // bufferでなく文字列として読み込み
+    const articleContents = fs.readFileSync(String(uploadArticlePath), 'utf-8');
+    // フロント・マターを区切り文字で検索し、フロント・マター以降を抽出
+    const startIndex = articleContents.indexOf(
+      '---',
+      articleContents.indexOf('---') + 1
+    );
+    const articleContentsBody = articleContents.substr(startIndex + 4);
+
+    // 記事投稿成功時に生成される記事idを格納する
+    let articleId = '';
+
+    await axios
+      .post<QiitaPostResponse>(
+        'https://qiita.com/api/v2/items/',
+        {
+          body: articleContentsBody,
+          coediting: false,
+          group_url_name: 'dev',
+          private: false,
+          tags: tags,
+          title: title,
+          tweet: false,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${qiitaSetting.token}`,
+          },
+        }
+      )
+      .then((res) => {
+        // console.log(res);
+        if (res.status === 201) {
+          // 記事投稿成功
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          articleId = String(res.data.id);
+          // 処理完了メッセージ
+          console.log(
+            '\n' +
+              emoji.get('sparkles') +
+              ' New Article "' +
+              String(title) +
+              '" is created' +
+              emoji.get('sparkles') +
+              '\n'
+          );
+        } else {
+          // 記事投稿失敗
+          console.log(
+            '\n' + emoji.get('disappointed') + ' fail to post new article.\n'
+          );
+          return -1;
+        }
+      });
+    // 投稿した記事を取得
+    await getArticle(articleId);
+    // 投稿前状態のファイルを削除
+    fs.unlinkSync(String(uploadArticlePath));
+    return 0;
+  } catch (e) {
+    const red = '\u001b[31m';
+    const reset = '\u001b[0m';
+    console.error('\n' + red + 'error in create new article: ' + reset + '\n');
+    console.error(e);
+    return -1;
   }
+  return 1;
 }

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -5,47 +5,46 @@ import fs from 'fs';
 // import qiitaSetting from '../qiita.json';
 import { QiitaPost } from '@/types/qiita';
 
-export class pullArticle {
-  async exec(): Promise<number> {
-    try {
-      // アクセストークン情報をqiita.jsonから取得
-      // qiita init で事前に設定されている必要あり
-      const homeDir =
-        process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      const qiitaDir = `${homeDir}/.qiita`;
-      const filePath = `${qiitaDir}/qiita.json`;
-      if (!fs.existsSync(filePath)) {
-        console.log(
-          emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
-        );
-        console.log(
-          'qiita init コマンドを実行してアクセストークンを設定してください.\n'
-        );
-        return -1;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const qiitaSetting: { token: string } = JSON.parse(
-        fs.readFileSync(filePath, 'utf-8')
+export async function pullArticle(): Promise<number> {
+  try {
+    // アクセストークン情報をqiita.jsonから取得
+    // qiita init で事前に設定されている必要あり
+    const homeDir =
+      process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME'];
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    const qiitaDir = `${homeDir}/.qiita`;
+    const filePath = `${qiitaDir}/qiita.json`;
+    if (!fs.existsSync(filePath)) {
+      console.log(
+        emoji.get('disappointed') + ' アクセストークンが設定されていません.\n'
       );
+      console.log(
+        'qiita init コマンドを実行してアクセストークンを設定してください.\n'
+      );
+      return -1;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const qiitaSetting: { token: string } = JSON.parse(
+      fs.readFileSync(filePath, 'utf-8')
+    );
 
-      console.log('fetching article ... ');
+    console.log('fetching article ... ');
 
-      await axios
-        .get<QiitaPost[]>('https://qiita.com/api/v2/authenticated_user/items', {
-          headers: {
-            Authorization: `Bearer ${qiitaSetting.token}`,
-          },
-        })
-        .then((res) => {
-          // make .md file from res data
-          console.log('------------------------------------------');
-          res.data.map((post) => {
-            console.log(post.id + ': ' + post.title);
-            const dir: string = 'articles/' + post.title + '/';
-            const filePath: string = dir + post.id + '.md';
-            fs.mkdirSync(dir, { recursive: true });
-            const frontMatter = `---
+    await axios
+      .get<QiitaPost[]>('https://qiita.com/api/v2/authenticated_user/items', {
+        headers: {
+          Authorization: `Bearer ${qiitaSetting.token}`,
+        },
+      })
+      .then((res) => {
+        // make .md file from res data
+        console.log('------------------------------------------');
+        res.data.map((post) => {
+          console.log(post.id + ': ' + post.title);
+          const dir: string = 'articles/' + post.title + '/';
+          const filePath: string = dir + post.id + '.md';
+          fs.mkdirSync(dir, { recursive: true });
+          const frontMatter = `---
 id: ${post.id}
 title: ${post.title}
 created_at: ${post.created_at}
@@ -57,29 +56,28 @@ likes_count: ${String(post.likes_count)}
 ---
 
 `;
-            // write frontMatter
-            fs.writeFileSync(filePath, frontMatter);
-            // write body
-            fs.appendFileSync(filePath, post.body);
-          });
-          console.log('------------------------------------------');
-          // 処理完了メッセージ
-          console.log(
-            '\n' +
-              emoji.get('sparkles') +
-              ' Article fetching completed. ' +
-              emoji.get('sparkles') +
-              '\n'
-          );
-          return 0;
+          // write frontMatter
+          fs.writeFileSync(filePath, frontMatter);
+          // write body
+          fs.appendFileSync(filePath, post.body);
         });
-    } catch (e) {
-      const red = '\u001b[31m';
-      const reset = '\u001b[0m';
-      console.error('\n' + red + 'error in get Qiita posts: ' + reset + '\n');
-      console.error(e);
-      return -1;
-    }
-    return 1;
+        console.log('------------------------------------------');
+        // 処理完了メッセージ
+        console.log(
+          '\n' +
+            emoji.get('sparkles') +
+            ' Article fetching completed. ' +
+            emoji.get('sparkles') +
+            '\n'
+        );
+        return 0;
+      });
+  } catch (e) {
+    const red = '\u001b[31m';
+    const reset = '\u001b[0m';
+    console.error('\n' + red + 'error in get Qiita posts: ' + reset + '\n');
+    console.error(e);
+    return -1;
   }
+  return 1;
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/28

## 対応概要

- 現状（As is）
  - `new accessTokenInitialize().exec()` のようにやっていることは `function()` を実行しているのみなのだがclassをnewして実行している

- 理想（To be）
  - class をやめてfunctionにする `accessTokenInitialize()` のように実行できるようにする

- 問題（Problem）
  - 変更量が多くなりがち

- 解決・やったこと（Action）
  - classをやめてfunctionの形になるようにした
  - ついでに `package.json` にformat コマンドを追加して `pretter` によるformatterを実行できるようにして、適宜実行するようにした

## 備考
