### PR TITLE
Refactor/use commander

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qiita-cli",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3816,6 +3816,11 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
+    },
+    "commander": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
     },
     "compare-func": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "commander": "^9.2.0",
     "inquirer": "^8.0.0",
     "open": "^8.0.7",
     "rehype-stringify": "^8.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,11 @@ program.storeOptionsAsProperties(false);
 program.version(
   packageJson.version,
   '-v, --version',
-  emoji.get('hatched_chick') + 'qiita cli ' + 'version: ' + packageJson.version
+  [
+    emoji.get('hatched_chick') + 'qiita cli',
+    'version:',
+    packageJson.version,
+  ].join(' ')
 );
 
 program.usage(mainUsage);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ program.version(
   emoji.get('hatched_chick') + 'qiita cli ' + 'version: ' + packageJson.version
 );
 
+program.usage(mainUsage);
+
 program.helpOption('-h, --help', 'ヘルプ');
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,15 +33,10 @@ program.storeOptionsAsProperties(false);
 program.version(
   packageJson.version,
   '-v, --version',
-  '\n' +
-    emoji.get('hatched_chick') +
-    'qiita cli' +
-    'version: ' +
-    packageJson.version +
-    '\n'
+  emoji.get('hatched_chick') + 'qiita cli ' + 'version: ' + packageJson.version
 );
 
-program.helpOption('-h, --help', mainUsage);
+program.helpOption('-h, --help', 'ヘルプ');
 
 program
   .command('init')

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,75 +6,83 @@ import { pullArticle } from './pullArticle';
 import packageJson from '../package.json';
 import { postArticle } from './postArticle';
 import { patchArticle } from './patchArticle';
+import { program } from 'commander';
 
-type CommandType =
-  | string
-  | 'init'
-  | 'pull:article'
-  | 'new:article'
-  | 'post:article'
-  | 'patch:article'
-  | 'delete:article'
-  | 'sync'
-  | 'version'
-  | 'help';
-
-class Main {
-  // command-line-usageがエラーが出て使えないので以下の実装
-  private readonly mainUsage: string = `Command:
-  qiita init                    qiitaとの接続設定. 初回のみ実行
-  qiita pull:article            既に投稿している記事をローカルにpull(強制上書き)
-  qiita new:article             新しい記事を追加
-  qiita post:article            ローカルで新規作成した記事を選択的に投稿
-  qiita patch:article           ローカルで修正した記事を選択的に投稿
-  qiita delete:article(未実装)   選択した記事の削除
-  qiita sync(未実装)             ローカルで作成/修正した記事の一括反映および投稿済み記事の取得
-  qiita --version, -v           qiita-cliのバージョンを表示
-  qiita --help, -h              ヘルプ
+const mainUsage: string = `Command:
+qiita init                    qiitaとの接続設定. 初回のみ実行
+qiita pull:article            既に投稿している記事をローカルにpull(強制上書き)
+qiita new:article             新しい記事を追加
+qiita post:article            ローカルで新規作成した記事を選択的に投稿
+qiita patch:article           ローカルで修正した記事を選択的に投稿
+qiita delete:article(未実装)   選択した記事の削除
+qiita sync(未実装)             ローカルで作成/修正した記事の一括反映および投稿済み記事の取得
+qiita --version, -v           qiita-cliのバージョンを表示
+qiita --help, -h              ヘルプ
 
 Remark:
-  コマンドは全て作業フォルダのルートでの実行を想定したものになっています.
-  記事の取得・投稿は作業フォルダはコマンド実行場所の作業フォルダ内のarticlesフォルダを基準に実行されます.
-  (articlesフォルダはqiita init や qiit pull コマンドで生成されます)
+コマンドは全て作業フォルダのルートでの実行を想定したものになっています.
+記事の取得・投稿は作業フォルダはコマンド実行場所の作業フォルダ内のarticlesフォルダを基準に実行されます.
+(articlesフォルダはqiita init や qiit pull コマンドで生成されます)
 `;
 
-  private commandMap = new Map<CommandType, () => number | Promise<number>>([
-    ['init', () => accessTokenInitialize()],
-    ['pull:article', () => pullArticle()],
-    ['new:article', () => newArticle()],
-    ['post:article', () => postArticle()],
-    ['patch:article', () => patchArticle()],
-    ['sync', () => new Calc().add(1, 2)],
-  ]);
+/**
+ * Set global CLI configurations
+ */
+program.storeOptionsAsProperties(false);
 
-  async run() {
-    // command-line-usageを利用しようとすると以下エラーを吐いてしまう
-    // TypeError: Cannot read property 'arrayify' of undefined
+program.version(
+  packageJson.version,
+  '-v, --version',
+  '\n' +
+    emoji.get('hatched_chick') +
+    'qiita cli' +
+    'version: ' +
+    packageJson.version +
+    '\n'
+);
 
-    console.log('\n' + emoji.get('hatched_chick') + ' qiita cli\n');
-    const exec = this.commandMap.get(process.argv[2]);
-    if (exec != null) {
-      const ret = await exec();
-      // TODO:Promise<numberの対応>
-      process.exit(ret);
-    } else {
-      if (process.argv[2] === '--help' || process.argv[2] === '-h') {
-        // help
-        console.log(this.mainUsage);
-      } else if (process.argv[2] === '--version' || process.argv[2] === '-v') {
-        // version
-        console.log('\n' + emoji.get('hatched_chick') + 'qiita cli');
-        console.log('version: ' + packageJson.version + '\n');
-      } else {
-        // other wrong args
-        console.log(
-          '\n' + emoji.get('disappointed') + ' wrong args\nfollow as below\n'
-        );
-        console.log(this.mainUsage);
-      }
-      process.exit(1);
-    }
-  }
-}
+program.helpOption('-h, --help', mainUsage);
 
-void new Main().run();
+program
+  .command('init')
+  .description('qiitaとの接続設定. 初回のみ実行')
+  .action(async () => {
+    await accessTokenInitialize();
+  });
+
+program
+  .command('pull:article')
+  .description('既に投稿している記事をローカルにpull(強制上書き)')
+  .action(async () => {
+    await pullArticle();
+  });
+
+program
+  .command('new:article')
+  .description('新しい記事を追加')
+  .action(async () => {
+    await newArticle();
+  });
+
+program
+  .command('post:article')
+  .description('ローカルで新規作成した記事を選択的に投稿')
+  .action(async () => {
+    await postArticle();
+  });
+
+program
+  .command('patch:article')
+  .description('ローカルで修正した記事を選択的に投稿')
+  .action(async () => {
+    await patchArticle();
+  });
+
+program
+  .command('sync')
+  .description('ローカルで作成/修正した記事の一括反映および投稿済み記事の取得')
+  .action(() => {
+    new Calc().add(1, 2);
+  });
+
+program.parse(process.argv);


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/30

## 対応概要

- 現状（As is）
  - [Commander.js](https://github.com/tj/commander.js) を使用せずに引数を使用からコマンドを認識するような処理になっている

- 理想（To be）
  - [Commander.js](https://github.com/tj/commander.js) を導入してコマンドラインツールの開発がしやすい形にする

- 問題（Problem）
  - [Commander.js](https://github.com/tj/commander.js) の仕様と既存のコマンドラインの仕様とを完全に一致する形にはできない(一部表示などが変わってしまっている)
  - 変更量が大きい

- 解決・やったこと（Action）
  -  [Commander.js](https://github.com/tj/commander.js) を導入し、既存の仕様を踏襲した上でCommanderでの実装形式にした

## 備考
