### PR TITLE
--token -t オプションでQiitaのaccessTokenをつけられるようにしました

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ program
     'Qiitaで発行したaccessTokenを入力してください'
   )
   .action(async (options: ExtraInputOptions) => {
-    await pullArticle();
+    await pullArticle(options);
   });
 
 program
@@ -78,7 +78,7 @@ program
     'Qiitaで発行したaccessTokenを入力してください'
   )
   .action(async (options: ExtraInputOptions) => {
-    await postArticle();
+    await postArticle(options);
   });
 
 program
@@ -89,7 +89,7 @@ program
     'Qiitaで発行したaccessTokenを入力してください'
   )
   .action(async (options: ExtraInputOptions) => {
-    await patchArticle();
+    await patchArticle(options);
   });
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import packageJson from '../package.json';
 import { postArticle } from './postArticle';
 import { patchArticle } from './patchArticle';
 import { program } from 'commander';
+import { ExtraInputOptions } from '~/types/command';
 
 const mainUsage: string = `Command:
 qiita init                    qiitaとの接続設定. 初回のみ実行
@@ -54,7 +55,11 @@ program
 program
   .command('pull:article')
   .description('既に投稿している記事をローカルにpull(強制上書き)')
-  .action(async () => {
+  .option(
+    '-t, --token <accessToken>',
+    'Qiitaで発行したaccessTokenを入力してください'
+  )
+  .action(async (options: ExtraInputOptions) => {
     await pullArticle();
   });
 
@@ -68,14 +73,22 @@ program
 program
   .command('post:article')
   .description('ローカルで新規作成した記事を選択的に投稿')
-  .action(async () => {
+  .option(
+    '-t, --token <accessToken>',
+    'Qiitaで発行したaccessTokenを入力してください'
+  )
+  .action(async (options: ExtraInputOptions) => {
     await postArticle();
   });
 
 program
   .command('patch:article')
   .description('ローカルで修正した記事を選択的に投稿')
-  .action(async () => {
+  .option(
+    '-t, --token <accessToken>',
+    'Qiitaで発行したaccessTokenを入力してください'
+  )
+  .action(async (options: ExtraInputOptions) => {
     await patchArticle();
   });
 

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -14,10 +14,15 @@ import path from 'path';
 import { QiitaPostResponse, Tag, FrontMatterParseResult } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import { loadArticleFiles } from './commons/articlesDirectory';
+import { ExtraInputOptions } from '~/types/command';
 
-export async function patchArticle(): Promise<number> {
+export async function patchArticle(
+  options: ExtraInputOptions
+): Promise<number> {
   try {
-    const qiitaSetting: { token: string } | null = loadInitializedAccessToken();
+    const qiitaSetting: { token: string } | null = options.token
+      ? { token: options.token }
+      : loadInitializedAccessToken();
     if (!qiitaSetting) {
       return -1;
     }

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -37,9 +37,9 @@ export async function patchArticle(
     const articleBaseDir = 'articles';
 
     // ファイル名がwill_be_patched.mdとなっているものを取得
-    const filePathList: string[] = loadArticleFiles(
-      articleBaseDir
-    ).filter((item) => item.includes('will_be_patched.md'));
+    const filePathList: string[] = loadArticleFiles(articleBaseDir).filter(
+      (item) => item.includes('will_be_patched.md')
+    );
 
     if (filePathList.length === 0) {
       console.log(

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -37,9 +37,9 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     const articleBaseDir = 'articles';
 
     // ファイル名がnot_uploaded.mdとなっているものを取得
-    const filePathList: string[] = loadArticleFiles(
-      articleBaseDir
-    ).filter((item) => item.includes('not_uploaded.md'));
+    const filePathList: string[] = loadArticleFiles(articleBaseDir).filter(
+      (item) => item.includes('not_uploaded.md')
+    );
 
     if (filePathList.length === 0) {
       console.log(

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -16,10 +16,13 @@ import { QiitaPostResponse, Tag, FrontMatterParseResult } from '~/types/qiita';
 import { getArticle } from './getArticle';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import { loadArticleFiles } from './commons/articlesDirectory';
+import { ExtraInputOptions } from '~/types/command';
 
-export async function postArticle(): Promise<number> {
+export async function postArticle(options: ExtraInputOptions): Promise<number> {
   try {
-    const qiitaSetting: { token: string } | null = loadInitializedAccessToken();
+    const qiitaSetting: { token: string } | null = options.token
+      ? { token: options.token }
+      : loadInitializedAccessToken();
     if (!qiitaSetting) {
       return -1;
     }

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -6,11 +6,14 @@ import path from 'path';
 // import qiitaSetting from '../qiita.json';
 import { QiitaPost } from '@/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
+import { ExtraInputOptions } from '~/types/command';
 
-export async function pullArticle(): Promise<number> {
+export async function pullArticle(options: ExtraInputOptions): Promise<number> {
   try {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const qiitaSetting: { token: string } | null = loadInitializedAccessToken();
+    const qiitaSetting: { token: string } | null = options.token
+      ? { token: options.token }
+      : loadInitializedAccessToken();
     if (!qiitaSetting) {
       return -1;
     }

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -1,3 +1,7 @@
 export interface commandLineArgs {
   command: string;
 }
+
+export interface ExtraInputOptions {
+  token: string;
+}


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/31

## 対応概要

- 現状（As is）
  - qiita initコマンドで生成されたファイルに記録されたaccesstokenの情報がないと他のこのライブラリを基本的に使えない

- 理想（To be）
  - コマンドオプションでaccesstokenを指定した場合でも本ライブラリを問題なく利用することができること

- 問題（Problem）
  - 特になし

- 解決・やったこと（Action）
  - コマンドオプションで `--token`、`-t` を指定できるようにした。コマンドオプションが指定されていないときはこれまでの従来通りの動きになるようにした。

## 備考
