### PR TITLE
管理する記事のディレクトリ名を articles 以外の名前を参照するようにコマンドオプションで指定できるようにしました close #48

### DIFF
--- a/src/accessTokenInitialize.ts
+++ b/src/accessTokenInitialize.ts
@@ -5,9 +5,7 @@ import open from 'open';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import sleep from 'sleep-promise';
 import { User } from '@/types/qiita';
-import path from 'path';
 import { initializeAndLoadQiitaDir } from './commons/qiitaSettings';
-import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function accessTokenInitialize(): Promise<number> {
   try {
@@ -75,12 +73,6 @@ export async function accessTokenInitialize(): Promise<number> {
     fs.writeFileSync(filePath, qiitaUserJson);
     fs.appendFileSync(filePath, '\n');
 
-    // 作業ディレクトリに記事用フォルダを作成
-    const articleDir = defaultProjectName;
-    if (!fs.existsSync(articleDir)) {
-      fs.mkdirSync(articleDir);
-    }
-
     // 処理完了メッセージ
     console.log(
       '\n' +
@@ -91,8 +83,6 @@ export async function accessTokenInitialize(): Promise<number> {
     );
     console.log('Your token has been saved to the following path:');
     console.log('\n' + '\t' + filePath + '\n');
-    console.log(['Your', articleDir, 'folder:'].join(' '));
-    console.log('\n' + '\t' + path.join(process.cwd(), articleDir) + '\n');
     return 0;
   } catch (e) {
     const red = '\u001b[31m';

--- a/src/accessTokenInitialize.ts
+++ b/src/accessTokenInitialize.ts
@@ -7,6 +7,7 @@ import sleep from 'sleep-promise';
 import { User } from '@/types/qiita';
 import path from 'path';
 import { initializeAndLoadQiitaDir } from './commons/qiitaSettings';
+import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function accessTokenInitialize(): Promise<number> {
   try {
@@ -75,7 +76,7 @@ export async function accessTokenInitialize(): Promise<number> {
     fs.appendFileSync(filePath, '\n');
 
     // 作業ディレクトリに記事用フォルダを作成
-    const articleDir = 'articles';
+    const articleDir = defaultProjectName;
     if (!fs.existsSync(articleDir)) {
       fs.mkdirSync(articleDir);
     }
@@ -90,8 +91,8 @@ export async function accessTokenInitialize(): Promise<number> {
     );
     console.log('Your token has been saved to the following path:');
     console.log('\n' + '\t' + filePath + '\n');
-    console.log('Your articles folder:');
-    console.log('\n' + '\t' + path.join(process.cwd(), 'articles') + '\n');
+    console.log(['Your', articleDir, 'folder:'].join(' '));
+    console.log('\n' + '\t' + path.join(process.cwd(), articleDir) + '\n');
     return 0;
   } catch (e) {
     const red = '\u001b[31m';

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -3,3 +3,5 @@ import fg from 'fast-glob';
 export function loadArticleFiles(rootDir: string): string[] {
   return fg.sync([rootDir, '**', '*.md'].join('/'), { dot: true });
 }
+
+export const defaultProjectName = 'articles';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import packageJson from '../package.json';
 import { postArticle } from './postArticle';
 import { patchArticle } from './patchArticle';
 import { program } from 'commander';
+import { defaultProjectName } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 const mainUsage: string = `Command:
@@ -59,6 +60,11 @@ program
     '-t, --token <accessToken>',
     'Qiitaで発行したaccessTokenを入力してください'
   )
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
+  )
   .action(async (options: ExtraInputOptions) => {
     await pullArticle(options);
   });
@@ -66,8 +72,13 @@ program
 program
   .command('new:article')
   .description('新しい記事を追加')
-  .action(async () => {
-    await newArticle();
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
+  )
+  .action(async (options: ExtraInputOptions) => {
+    await newArticle(options);
   });
 
 program
@@ -76,6 +87,11 @@ program
   .option(
     '-t, --token <accessToken>',
     'Qiitaで発行したaccessTokenを入力してください'
+  )
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
   )
   .action(async (options: ExtraInputOptions) => {
     await postArticle(options);
@@ -87,6 +103,11 @@ program
   .option(
     '-t, --token <accessToken>',
     'Qiitaで発行したaccessTokenを入力してください'
+  )
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
   )
   .action(async (options: ExtraInputOptions) => {
     await patchArticle(options);

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -4,7 +4,6 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
-import { defaultProjectName } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function newArticle(options: ExtraInputOptions): Promise<number> {
@@ -24,7 +23,7 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
     );
 
     // 作業ディレクトリに記事用フォルダを作成
-    const articleBaseDir = defaultProjectName;
+    const articleBaseDir = options.project;
     if (!fs.existsSync(articleBaseDir)) {
       fs.mkdirSync(articleBaseDir);
     }

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -4,6 +4,7 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
+import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function newArticle(): Promise<number> {
   try {
@@ -22,7 +23,7 @@ export async function newArticle(): Promise<number> {
     );
 
     // 作業ディレクトリに記事用フォルダを作成
-    const articleBaseDir = 'articles';
+    const articleBaseDir = defaultProjectName;
     if (!fs.existsSync(articleBaseDir)) {
       fs.mkdirSync(articleBaseDir);
     }

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -5,8 +5,9 @@ import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
 import { defaultProjectName } from './commons/articlesDirectory';
+import { ExtraInputOptions } from '~/types/command';
 
-export async function newArticle(): Promise<number> {
+export async function newArticle(options: ExtraInputOptions): Promise<number> {
   try {
     console.log('Qiita 記事新規作成\n');
 

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -6,7 +6,10 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  defaultProjectName,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function patchArticle(
@@ -27,7 +30,7 @@ export async function patchArticle(
     console.log(
       'articleディレクトリ内の will_be_patched.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = 'articles';
+    const articleBaseDir = defaultProjectName;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const updateCandidateMatterMarkdowns: {

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -6,10 +6,7 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import {
-  loadArticleFiles,
-  defaultProjectName,
-} from './commons/articlesDirectory';
+import { loadArticleFiles } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function patchArticle(
@@ -30,7 +27,7 @@ export async function patchArticle(
     console.log(
       'articleディレクトリ内の will_be_patched.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = defaultProjectName;
+    const articleBaseDir = options.project;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const updateCandidateMatterMarkdowns: {

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -5,7 +5,10 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  defaultProjectName,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function postArticle(options: ExtraInputOptions): Promise<number> {
@@ -24,7 +27,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     console.log(
       'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = 'articles';
+    const articleBaseDir = defaultProjectName;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const newPostCandidateMatterMarkdowns: {

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -5,10 +5,7 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import {
-  loadArticleFiles,
-  defaultProjectName,
-} from './commons/articlesDirectory';
+import { loadArticleFiles } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function postArticle(options: ExtraInputOptions): Promise<number> {
@@ -27,7 +24,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     console.log(
       'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = defaultProjectName;
+    const articleBaseDir = options.project;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const newPostCandidateMatterMarkdowns: {

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { QiitaPost } from '@/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import { ExtraInputOptions } from '~/types/command';
+import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function pullArticle(options: ExtraInputOptions): Promise<number> {
   try {
@@ -32,7 +33,7 @@ export async function pullArticle(options: ExtraInputOptions): Promise<number> {
     console.log('------------------------------------------');
     res.data.map((post) => {
       console.log(post.id + ': ' + post.title);
-      const dir: string = path.join('articles', post.title);
+      const dir: string = path.join(defaultProjectName, post.title);
       const filePath: string = path.join(dir, post.id + '.md');
       fs.mkdirSync(dir, { recursive: true });
       const frontMatter = `---

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -7,7 +7,6 @@ import path from 'path';
 import { QiitaPost } from '@/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import { ExtraInputOptions } from '~/types/command';
-import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function pullArticle(options: ExtraInputOptions): Promise<number> {
   try {
@@ -33,7 +32,7 @@ export async function pullArticle(options: ExtraInputOptions): Promise<number> {
     console.log('------------------------------------------');
     res.data.map((post) => {
       console.log(post.id + ': ' + post.title);
-      const dir: string = path.join(defaultProjectName, post.title);
+      const dir: string = path.join(options.project, post.title);
       const filePath: string = path.join(dir, post.id + '.md');
       fs.mkdirSync(dir, { recursive: true });
       const frontMatter = `---

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -4,4 +4,5 @@ export interface commandLineArgs {
 
 export interface ExtraInputOptions {
   token: string;
+  project: string;
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/48

## 対応概要

- 現状（As is）
  - projectの名前が `articles` 固定であることが想定された作りになっている

- 理想（To be）
  - project の名前は利用者が好きに指定することができる

- 問題（Problem）
  - 

- 解決・やったこと（Action）
  - コマンドオプション `--project -p` の入力により記事を書いている基底のディレクトリの名前(パス)を参照できるようになった
  - `articles` とハードコーディングしている部分を共通化した

## 備考
