### PR TITLE
すでに投稿されているファイルをすべてダウンロードされるようにした close #53 #45 #38

### DIFF
--- a/src/accessTokenInitialize.ts
+++ b/src/accessTokenInitialize.ts
@@ -5,9 +5,7 @@ import open from 'open';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import sleep from 'sleep-promise';
 import { User } from '@/types/qiita';
-import path from 'path';
 import { initializeAndLoadQiitaDir } from './commons/qiitaSettings';
-import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function accessTokenInitialize(): Promise<number> {
   try {
@@ -75,12 +73,6 @@ export async function accessTokenInitialize(): Promise<number> {
     fs.writeFileSync(filePath, qiitaUserJson);
     fs.appendFileSync(filePath, '\n');
 
-    // 作業ディレクトリに記事用フォルダを作成
-    const articleDir = defaultProjectName;
-    if (!fs.existsSync(articleDir)) {
-      fs.mkdirSync(articleDir);
-    }
-
     // 処理完了メッセージ
     console.log(
       '\n' +
@@ -91,8 +83,6 @@ export async function accessTokenInitialize(): Promise<number> {
     );
     console.log('Your token has been saved to the following path:');
     console.log('\n' + '\t' + filePath + '\n');
-    console.log(['Your', articleDir, 'folder:'].join(' '));
-    console.log('\n' + '\t' + path.join(process.cwd(), articleDir) + '\n');
     return 0;
   } catch (e) {
     const red = '\u001b[31m';

--- a/src/accessTokenInitialize.ts
+++ b/src/accessTokenInitialize.ts
@@ -7,6 +7,7 @@ import sleep from 'sleep-promise';
 import { User } from '@/types/qiita';
 import path from 'path';
 import { initializeAndLoadQiitaDir } from './commons/qiitaSettings';
+import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function accessTokenInitialize(): Promise<number> {
   try {
@@ -75,7 +76,7 @@ export async function accessTokenInitialize(): Promise<number> {
     fs.appendFileSync(filePath, '\n');
 
     // 作業ディレクトリに記事用フォルダを作成
-    const articleDir = 'articles';
+    const articleDir = defaultProjectName;
     if (!fs.existsSync(articleDir)) {
       fs.mkdirSync(articleDir);
     }
@@ -90,8 +91,8 @@ export async function accessTokenInitialize(): Promise<number> {
     );
     console.log('Your token has been saved to the following path:');
     console.log('\n' + '\t' + filePath + '\n');
-    console.log('Your articles folder:');
-    console.log('\n' + '\t' + path.join(process.cwd(), 'articles') + '\n');
+    console.log(['Your', articleDir, 'folder:'].join(' '));
+    console.log('\n' + '\t' + path.join(process.cwd(), articleDir) + '\n');
     return 0;
   } catch (e) {
     const red = '\u001b[31m';

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -3,3 +3,5 @@ import fg from 'fast-glob';
 export function loadArticleFiles(rootDir: string): string[] {
   return fg.sync([rootDir, '**', '*.md'].join('/'), { dot: true });
 }
+
+export const defaultProjectName = 'articles';

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -1,7 +1,28 @@
 import fg from 'fast-glob';
+import fs from 'fs';
+import matter from 'gray-matter';
+import { QiitaPost } from '~/types/qiita';
 
 export function loadArticleFiles(rootDir: string): string[] {
   return fg.sync([rootDir, '**', '*.md'].join('/'), { dot: true });
 }
 
 export const defaultProjectName = 'articles';
+
+export function writeFrontmatterMarkdownFileWithQiitaPost(
+  filePath: string,
+  qiitaPost: QiitaPost
+) {
+  const saveMarkdownFile = matter.stringify(qiitaPost.body, {
+    id: qiitaPost.id,
+    title: qiitaPost.title,
+    created_at: qiitaPost.created_at,
+    updated_at: qiitaPost.updated_at,
+    tags: JSON.stringify(qiitaPost.tags),
+    private: qiitaPost.private,
+    url: qiitaPost.url,
+    likes_count: qiitaPost.likes_count,
+  });
+  // write frontMatter
+  fs.writeFileSync(filePath, saveMarkdownFile);
+}

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -13,9 +13,12 @@ export function writeFrontmatterMarkdownFileWithQiitaPost(
   filePath: string,
   qiitaPost: QiitaPost
 ) {
+  const group_url_name = qiitaPost.group ? qiitaPost.group.url_name : null;
   const saveMarkdownFile = matter.stringify(qiitaPost.body, {
     id: qiitaPost.id,
     title: qiitaPost.title,
+    coediting: qiitaPost.coediting,
+    group_url_name: group_url_name,
     created_at: qiitaPost.created_at,
     updated_at: qiitaPost.updated_at,
     tags: qiitaPost.tags.map((tagObj) => {

--- a/src/commons/articlesDirectory.ts
+++ b/src/commons/articlesDirectory.ts
@@ -18,7 +18,9 @@ export function writeFrontmatterMarkdownFileWithQiitaPost(
     title: qiitaPost.title,
     created_at: qiitaPost.created_at,
     updated_at: qiitaPost.updated_at,
-    tags: JSON.stringify(qiitaPost.tags),
+    tags: qiitaPost.tags.map((tagObj) => {
+      return { name: tagObj.name };
+    }),
     private: qiitaPost.private,
     url: qiitaPost.url,
     likes_count: qiitaPost.likes_count,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import packageJson from '../package.json';
 import { postArticle } from './postArticle';
 import { patchArticle } from './patchArticle';
 import { program } from 'commander';
+import { defaultProjectName } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 const mainUsage: string = `Command:
@@ -59,6 +60,11 @@ program
     '-t, --token <accessToken>',
     'Qiitaで発行したaccessTokenを入力してください'
   )
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
+  )
   .action(async (options: ExtraInputOptions) => {
     await pullArticle(options);
   });
@@ -66,8 +72,13 @@ program
 program
   .command('new:article')
   .description('新しい記事を追加')
-  .action(async () => {
-    await newArticle();
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
+  )
+  .action(async (options: ExtraInputOptions) => {
+    await newArticle(options);
   });
 
 program
@@ -76,6 +87,11 @@ program
   .option(
     '-t, --token <accessToken>',
     'Qiitaで発行したaccessTokenを入力してください'
+  )
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
   )
   .action(async (options: ExtraInputOptions) => {
     await postArticle(options);
@@ -87,6 +103,11 @@ program
   .option(
     '-t, --token <accessToken>',
     'Qiitaで発行したaccessTokenを入力してください'
+  )
+  .option(
+    '-p, --project <baseProjectPath>',
+    `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
+    defaultProjectName
   )
   .action(async (options: ExtraInputOptions) => {
     await patchArticle(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,10 @@ program
     `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
     defaultProjectName
   )
+  .option(
+    '-f, --file <uploadFilePath>',
+    `投稿したい記事のファイルを指定してください`
+  )
   .action(async (options: ExtraInputOptions) => {
     await postArticle(options);
   });
@@ -108,6 +112,10 @@ program
     '-p, --project <baseProjectPath>',
     `記事の取得・投稿を行うための作業ディレクトリの場所を指定してください。(default: ${defaultProjectName})`,
     defaultProjectName
+  )
+  .option(
+    '-f, --file <uploadFilePath>',
+    `投稿したい記事のファイルを指定してください`
   )
   .action(async (options: ExtraInputOptions) => {
     await patchArticle(options);

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -79,7 +79,7 @@ qiita cliはローカル上で新規記事/修正記事かどうかはファイ�
     const saveMarkdownFile = matter.stringify(body, {
       id: '',
       title: answers.article_title,
-      tags: [{ name: 'qiita-cli', versions: [] }],
+      tags: [{ name: 'qiita-cli' }],
     });
     // write frontMatter
     fs.writeFileSync(articlePath, saveMarkdownFile);

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -4,6 +4,7 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
+import matter from 'gray-matter';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function newArticle(options: ExtraInputOptions): Promise<number> {
@@ -53,12 +54,6 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
     } else {
       fs.mkdirSync(articleDir);
     }
-    const frontMatter = `---
-id: 
-title: ${answers.article_title}
-tags: [{"name":"qiita-cli","versions":[]}]
----  
-      `;
     const body = `
 ここから本文を書く
 # ${emoji.get('hatched_chick')} qiita cliによる自動生成です.
@@ -81,9 +76,13 @@ tags: [{"name":"C++","versions":[]},{"name":"AtCoder","versions":[]}]
 qiita cliはローカル上で新規記事/修正記事かどうかはファイル名により判断します.
 \`not_uploaded.md\`というファイル名はそのままに ${emoji.get('bow')}
 `;
-    // sync writ for frontMatter
-    fs.writeFileSync(articlePath, frontMatter);
-    fs.appendFileSync(articlePath, body);
+    const saveMarkdownFile = matter.stringify(body, {
+      id: '',
+      title: answers.article_title,
+      tags: [{ name: 'qiita-cli', versions: [] }],
+    });
+    // write frontMatter
+    fs.writeFileSync(articlePath, saveMarkdownFile);
 
     // 処理完了メッセージ
     console.log(

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -4,7 +4,6 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
-import { defaultProjectName } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function newArticle(options: ExtraInputOptions): Promise<number> {
@@ -24,7 +23,7 @@ export async function newArticle(options: ExtraInputOptions): Promise<number> {
     );
 
     // 作業ディレクトリに記事用フォルダを作成
-    const articleBaseDir = defaultProjectName;
+    const articleBaseDir = options.project;
     if (!fs.existsSync(articleBaseDir)) {
       fs.mkdirSync(articleBaseDir);
     }

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -4,6 +4,7 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
+import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function newArticle(): Promise<number> {
   try {
@@ -22,7 +23,7 @@ export async function newArticle(): Promise<number> {
     );
 
     // 作業ディレクトリに記事用フォルダを作成
-    const articleBaseDir = 'articles';
+    const articleBaseDir = defaultProjectName;
     if (!fs.existsSync(articleBaseDir)) {
       fs.mkdirSync(articleBaseDir);
     }

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -5,8 +5,9 @@ import fs from 'fs';
 import { Answers, prompt, QuestionCollection } from 'inquirer';
 import path from 'path';
 import { defaultProjectName } from './commons/articlesDirectory';
+import { ExtraInputOptions } from '~/types/command';
 
-export async function newArticle(): Promise<number> {
+export async function newArticle(options: ExtraInputOptions): Promise<number> {
   try {
     console.log('Qiita 記事新規作成\n');
 

--- a/src/newArticle.ts
+++ b/src/newArticle.ts
@@ -80,6 +80,7 @@ qiita cliはローカル上で新規記事/修正記事かどうかはファイ�
       id: '',
       title: answers.article_title,
       tags: [{ name: 'qiita-cli' }],
+      private: true,
     });
     // write frontMatter
     fs.writeFileSync(articlePath, saveMarkdownFile);

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -4,9 +4,12 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
-import { QiitaPostResponse, Tag } from '~/types/qiita';
+import { QiitaPost, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  writeFrontmatterMarkdownFileWithQiitaPost,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function patchArticle(
@@ -53,7 +56,7 @@ export async function patchArticle(
     // 記事id
     const articleId: string = uploadMatterMarkdown.data.id;
 
-    const res = await axios.patch<QiitaPostResponse>(
+    const res = await axios.patch<QiitaPost>(
       'https://qiita.com/api/v2/items/' + String(articleId),
       {
         body: articleContentsBody,
@@ -82,6 +85,7 @@ export async function patchArticle(
           emoji.get('sparkles') +
           '\n'
       );
+      writeFrontmatterMarkdownFileWithQiitaPost(postFilePath, res.data);
     } else {
       // 記事投稿失敗
       console.log(

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -6,7 +6,10 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  defaultProjectName,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function patchArticle(
@@ -27,7 +30,7 @@ export async function patchArticle(
     console.log(
       'articleディレクトリ内の will_be_patched.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = 'articles';
+    const articleBaseDir = defaultProjectName;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const updateCandidateMatterMarkdowns: {

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -60,9 +60,9 @@ export async function patchArticle(
       'https://qiita.com/api/v2/items/' + String(articleId),
       {
         body: articleContentsBody,
-        coediting: false,
-        group_url_name: 'dev',
-        private: false,
+        coediting: uploadMatterMarkdown.data.coediting,
+        group_url_name: uploadMatterMarkdown.data.group_url_name,
+        private: uploadMatterMarkdown.data.private || false,
         tags: tags,
         title: title,
       },

--- a/src/patchArticle.ts
+++ b/src/patchArticle.ts
@@ -6,10 +6,7 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import {
-  loadArticleFiles,
-  defaultProjectName,
-} from './commons/articlesDirectory';
+import { loadArticleFiles } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function patchArticle(
@@ -30,7 +27,7 @@ export async function patchArticle(
     console.log(
       'articleディレクトリ内の will_be_patched.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = defaultProjectName;
+    const articleBaseDir = options.project;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const updateCandidateMatterMarkdowns: {

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -55,9 +55,9 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
       'https://qiita.com/api/v2/items/',
       {
         body: articleContentsBody,
-        coediting: false,
-        group_url_name: 'dev',
-        private: false,
+        coediting: uploadMatterMarkdown.data.coediting,
+        group_url_name: uploadMatterMarkdown.data.group_url_name,
+        private: uploadMatterMarkdown.data.private || false,
         tags: tags,
         title: title,
         tweet: false,

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -5,7 +5,10 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  defaultProjectName,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function postArticle(options: ExtraInputOptions): Promise<number> {
@@ -24,7 +27,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     console.log(
       'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = 'articles';
+    const articleBaseDir = defaultProjectName;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const newPostCandidateMatterMarkdowns: {

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -24,52 +24,22 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     console.log(
       'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = options.project;
-
-    const filePathList: string[] = loadArticleFiles(articleBaseDir);
-    const newPostCandidateMatterMarkdowns: {
-      [s: string]: GrayMatterFile<string>;
-    } = {};
-    for (const filePath of filePathList) {
-      const parsedMatter = matter(fs.readFileSync(filePath, 'utf-8'));
-      if (!parsedMatter.data.id && parsedMatter.data.title) {
-        newPostCandidateMatterMarkdowns[filePath] = parsedMatter;
-      }
-    }
-
-    if (Object.keys(newPostCandidateMatterMarkdowns).length === 0) {
+    const postFilePath = options.file
+      ? options.file
+      : await selectPostFilePath(options.project);
+    if (!postFilePath) {
       console.log(
         '\n' +
           emoji.get('disappointed') +
-          ' There are no "will_be_patched.md" files\n'
+          ' There are no "not_uploaded.md" files\n'
       );
       console.log(emoji.get('hatched_chick') + ' 処理を中止しました\n');
       return 1;
     }
 
-    //   typ: 'checkbox'とすることで、複数選択可能状態にできるが、シェル上で挙動が不安定になるので、一旦単一選択のlistを採用
-    const inputQuestions: QuestionCollection = [
-      {
-        type: 'list',
-        message: 'アップロードする記事を選択してください: ',
-        name: 'uploadArticles',
-        choices: Object.keys(newPostCandidateMatterMarkdowns),
-      },
-    ];
-    const answers = await prompt(inputQuestions);
-
-    const postFilePath = answers.uploadArticles;
-    //   TODO: 複数選択対応
-    const uploadMatterMarkdown: GrayMatterFile<string> | undefined =
-      newPostCandidateMatterMarkdowns[postFilePath];
-
-    if (!uploadMatterMarkdown) {
-      // 記事投稿失敗
-      console.log(
-        '\n' + emoji.get('disappointed') + ' fail to post new article.\n'
-      );
-      return -1;
-    }
+    const uploadMatterMarkdown: GrayMatterFile<string> = matter(
+      fs.readFileSync(postFilePath, 'utf-8')
+    );
 
     // 記事タイトル
     const title: string = uploadMatterMarkdown.data.title || '';
@@ -135,4 +105,32 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     return -1;
   }
   return 1;
+}
+
+async function selectPostFilePath(rootDir: string): Promise<string> {
+  const filePathList: string[] = loadArticleFiles(rootDir);
+  const postCandidateFilePathes: string[] = [];
+  for (const filePath of filePathList) {
+    const parsedMatter = matter(fs.readFileSync(filePath, 'utf-8'));
+    if (!parsedMatter.data.id && parsedMatter.data.title) {
+      postCandidateFilePathes.push(filePath);
+    }
+  }
+
+  if (postCandidateFilePathes.length === 0) {
+    return '';
+  }
+
+  //   typ: 'checkbox'とすることで、複数選択可能状態にできるが、シェル上で挙動が不安定になるので、一旦単一選択のlistを採用
+  const inputQuestions: QuestionCollection = [
+    {
+      type: 'list',
+      message: 'アップロードする記事を選択してください: ',
+      name: 'uploadArticles',
+      choices: postCandidateFilePathes,
+    },
+  ];
+  const answers = await prompt(inputQuestions);
+
+  return answers.uploadArticles;
 }

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -5,10 +5,7 @@ import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
 import { QiitaPostResponse, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import {
-  loadArticleFiles,
-  defaultProjectName,
-} from './commons/articlesDirectory';
+import { loadArticleFiles } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function postArticle(options: ExtraInputOptions): Promise<number> {
@@ -27,7 +24,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     console.log(
       'articleディレクトリ内の not_uploaded.md ファイルが投稿候補記事として認識されます\n\n'
     );
-    const articleBaseDir = defaultProjectName;
+    const articleBaseDir = options.project;
 
     const filePathList: string[] = loadArticleFiles(articleBaseDir);
     const newPostCandidateMatterMarkdowns: {

--- a/src/postArticle.ts
+++ b/src/postArticle.ts
@@ -3,9 +3,12 @@ import emoji from 'node-emoji';
 import fs from 'fs';
 import { prompt, QuestionCollection } from 'inquirer';
 import matter, { GrayMatterFile } from 'gray-matter';
-import { QiitaPostResponse, Tag } from '~/types/qiita';
+import { QiitaPost, Tag } from '~/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
-import { loadArticleFiles } from './commons/articlesDirectory';
+import {
+  loadArticleFiles,
+  writeFrontmatterMarkdownFileWithQiitaPost,
+} from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 export async function postArticle(options: ExtraInputOptions): Promise<number> {
@@ -48,7 +51,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
     // 記事本文
     const articleContentsBody = uploadMatterMarkdown.content;
 
-    const res = await axios.post<QiitaPostResponse>(
+    const res = await axios.post<QiitaPost>(
       'https://qiita.com/api/v2/items/',
       {
         body: articleContentsBody,
@@ -78,17 +81,7 @@ export async function postArticle(options: ExtraInputOptions): Promise<number> {
           emoji.get('sparkles') +
           '\n'
       );
-      const renewalPost = matter.stringify(postData.body, {
-        id: postData.id,
-        title: postData.title,
-        created_at: postData.created_at,
-        updated_at: postData.updated_at,
-        tags: JSON.stringify(postData.tags),
-        private: postData.private,
-        url: postData.url,
-        likes_count: postData.likes_count,
-      });
-      fs.writeFileSync(postFilePath, renewalPost);
+      writeFrontmatterMarkdownFileWithQiitaPost(postFilePath, postData);
     } else {
       // 記事投稿失敗
       console.log(

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { QiitaPost } from '@/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import { ExtraInputOptions } from '~/types/command';
+import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function pullArticle(options: ExtraInputOptions): Promise<number> {
   try {
@@ -32,7 +33,7 @@ export async function pullArticle(options: ExtraInputOptions): Promise<number> {
     console.log('------------------------------------------');
     res.data.map((post) => {
       console.log(post.id + ': ' + post.title);
-      const dir: string = path.join('articles', post.title);
+      const dir: string = path.join(defaultProjectName, post.title);
       const filePath: string = path.join(dir, post.id + '.md');
       fs.mkdirSync(dir, { recursive: true });
       const frontMatter = `---

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -2,7 +2,6 @@ import axios, { AxiosResponse } from 'axios';
 import emoji from 'node-emoji';
 import fs from 'fs';
 import path from 'path';
-import matter from 'gray-matter';
 // import 形式だとファイルが存在しない状態でエラーが起こるので、import形式を一旦取りやめる
 // import qiitaSetting from '../qiita.json';
 import { QiitaPost, User } from '@/types/qiita';

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -7,7 +7,6 @@ import path from 'path';
 import { QiitaPost } from '@/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
 import { ExtraInputOptions } from '~/types/command';
-import { defaultProjectName } from './commons/articlesDirectory';
 
 export async function pullArticle(options: ExtraInputOptions): Promise<number> {
   try {
@@ -33,7 +32,7 @@ export async function pullArticle(options: ExtraInputOptions): Promise<number> {
     console.log('------------------------------------------');
     res.data.map((post) => {
       console.log(post.id + ': ' + post.title);
-      const dir: string = path.join(defaultProjectName, post.title);
+      const dir: string = path.join(options.project, post.title);
       const filePath: string = path.join(dir, post.id + '.md');
       fs.mkdirSync(dir, { recursive: true });
       const frontMatter = `---

--- a/src/pullArticle.ts
+++ b/src/pullArticle.ts
@@ -7,6 +7,7 @@ import matter from 'gray-matter';
 // import qiitaSetting from '../qiita.json';
 import { QiitaPost, User } from '@/types/qiita';
 import { loadInitializedAccessToken } from './commons/qiitaSettings';
+import { writeFrontmatterMarkdownFileWithQiitaPost } from './commons/articlesDirectory';
 import { ExtraInputOptions } from '~/types/command';
 
 const itemsPerPage = 100;
@@ -36,18 +37,7 @@ export async function pullArticle(options: ExtraInputOptions): Promise<number> {
         const dir: string = path.join(options.project, post.title);
         const filePath: string = path.join(dir, post.id + '.md');
         fs.mkdirSync(dir, { recursive: true });
-        const saveMarkdownFile = matter.stringify(post.body, {
-          id: post.id,
-          title: post.title,
-          created_at: post.created_at,
-          updated_at: post.updated_at,
-          tags: JSON.stringify(post.tags),
-          private: post.private,
-          url: post.url,
-          likes_count: post.likes_count,
-        });
-        // write frontMatter
-        fs.writeFileSync(filePath, saveMarkdownFile);
+        writeFrontmatterMarkdownFileWithQiitaPost(filePath, post);
       }
       console.log('------------------------------------------');
       if (itemCount <= page * itemsPerPage) {

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -4,4 +4,5 @@ export interface commandLineArgs {
 
 export interface ExtraInputOptions {
   token: string;
+  project: string;
 }

--- a/types/command.d.ts
+++ b/types/command.d.ts
@@ -5,4 +5,5 @@ export interface commandLineArgs {
 export interface ExtraInputOptions {
   token: string;
   project: string;
+  file: string;
 }

--- a/types/qiita.d.ts
+++ b/types/qiita.d.ts
@@ -4,7 +4,7 @@ export interface QiitaPost {
   coediting: boolean;
   comments_count: number;
   created_at: string;
-  group: null;
+  group: null | Group;
   id: string;
   likes_count: number;
   private: boolean;
@@ -14,44 +14,7 @@ export interface QiitaPost {
   updated_at: string;
   url: string;
   user: User;
-  page_views_count: null;
-}
-
-export interface QiitaPostResponse {
-  rendered_body: string;
-  body: string;
-  coediting: boolean;
-  comments_count: number;
-  created_at: string;
-  group: null | string;
-  id: string;
-  likes_count: number;
-  private: boolean;
-  reactions_count: number;
-  tags: [];
-  title: string;
-  updated_at: string;
-  url: string;
-  user: {
-    description: string;
-    facebook_id: string;
-    followees_count: number;
-    followers_count: number;
-    github_login_name: string;
-    id: string;
-    items_count: number;
-    linkedin_id: string;
-    location: string;
-    name: string;
-    organization: string;
-    permanent_id: number;
-    profile_image_url: string;
-    team_only: boolean;
-    twitter_screen_name: null | string;
-    website_url: string;
-  };
-  page_views_count: null | string;
-  team_membership: null | string;
+  page_views_count: number;
 }
 
 export interface Tag {
@@ -60,20 +23,29 @@ export interface Tag {
 }
 
 export interface User {
-  description: null | string;
-  facebook_id: null | string;
+  description: string;
+  facebook_id: string;
   followees_count: number;
   followers_count: number;
-  github_login_name: null | string;
+  github_login_name: string;
   id: string;
   items_count: number;
-  linkedin_id: null | string;
-  location: null | string;
+  linkedin_id: string;
+  location: string;
   name: string;
-  organization: string | null;
+  organization: string;
   permanent_id: number;
   profile_image_url: string;
   team_only: boolean;
-  twitter_screen_name: null | string;
-  website_url: null | string;
+  twitter_screen_name: string;
+  website_url: string;
+}
+
+export interface Group {
+  created_at: string,
+  description: string,
+  name: string,
+  private: boolean,
+  updated_at: string,
+  url_name: string,
 }


### PR DESCRIPTION
## 対応issue

https://github.com/antyuntyuntyun/qiita-cli/issues/53
https://github.com/antyuntyuntyun/qiita-cli/issues/45
https://github.com/antyuntyuntyun/qiita-cli/issues/38

## 対応概要

- 現状（As is）
  - 記事のダウンロードは全件ではなく100件ぐらいまでと思われる

- 理想（To be）
  - 可能な限り(最大10000件) の記事をダウンロードできるようにしたい

- 問題（Problem）
  - 本件の実装にあたり細かい部分での使用感も変更した
    - 投稿する時に付与する必要がある情報も全て記事のfront-matterに書き込まれるように修正した
    - front-matterの値を参照して記事を投稿するように変更した
  - Qiita APIにて使われている型(interface)も一緒に整理&共通化した
  - 結果的にいくつかのissueも一緒に対応することになってしまった

- 解決・やったこと（Action）
  - 可能な限り(最大10000件)の記事をダウンロードできるようにした
  - Qiita API関係の型(interface) の共通化と整理を行った
  - front-matterへの書き込みは gray-matter を使用したものに統一した
    - これに関連して tags の部分をJSONではなくyamlの形で保存されるようにした
    - tagsの中にversionsの項目があると投稿時にエラーとなってしまうので、これは除去した

## 備考
https://github.com/antyuntyuntyun/qiita-cli/pull/50
https://github.com/antyuntyuntyun/qiita-cli/pull/51
こちら上から順番に上記のPRが適用された後にこちらのPRを見ていただければと思います。
本件の実装にあたり付随していたissueも巻き込んだ形で対応してしまっております。
動作の確認をして問題がないことは確認していますが、変更を希望するところなどありましたらご指摘ください。
よろしくお願いします